### PR TITLE
Block player controls when level timer expires

### DIFF
--- a/Assets/Prefabs/Player.prefab
+++ b/Assets/Prefabs/Player.prefab
@@ -296,6 +296,7 @@ MonoBehaviour:
   rigidBody: {fileID: 2127368311968531779}
   playerModelRenderer: {fileID: 482893924135192172}
   player: {fileID: 5674135250990863131}
+  interactor: {fileID: 8694444420510392368}
   moveSpeed: 70
   rotationSpeed: 1000
 --- !u!114 &8694444420510392368

--- a/Assets/Prefabs/Player.prefab
+++ b/Assets/Prefabs/Player.prefab
@@ -295,6 +295,7 @@ MonoBehaviour:
   syncInterval: 0.1
   rigidBody: {fileID: 2127368311968531779}
   playerModelRenderer: {fileID: 482893924135192172}
+  player: {fileID: 5674135250990863131}
   moveSpeed: 70
   rotationSpeed: 1000
 --- !u!114 &8694444420510392368

--- a/Assets/Scripts/Player.cs
+++ b/Assets/Scripts/Player.cs
@@ -26,6 +26,15 @@ namespace Underconnected
         /// The player connection this player belongs to.
         /// </summary>
         public PlayerConnection Client { get; private set; }
+        /// <summary>
+        /// The player controls instance that listens for inputs and moves this player.
+        /// </summary>
+        public PlayerControls Controls => this.controls;
+
+        /// <summary>
+        /// Tells whether this player is our own player that we can control.
+        /// </summary>
+        public bool IsOwnPlayer => this.hasAuthority;
 
 
         #region Unity Callbacks
@@ -59,7 +68,7 @@ namespace Underconnected
         /// </summary>
         private void Update()
         {
-            if (this.hasAuthority)
+            if (this.IsOwnPlayer && this.Controls.ControlsEnabled)
             {
                 if (Input.GetKeyDown(KeyCode.E))
                     this.interactor.Interact();

--- a/Assets/Scripts/Player.cs
+++ b/Assets/Scripts/Player.cs
@@ -63,18 +63,6 @@ namespace Underconnected
                 GameManager.CurrentLevel.UnregisterPlayer(this);
         }
 
-        /// <summary>
-        /// Will check if local player presses the 'E' key and if so calls <see cref="Interactor.Interact"/>.
-        /// </summary>
-        private void Update()
-        {
-            if (this.IsOwnPlayer && this.Controls.ControlsEnabled)
-            {
-                if (Input.GetKeyDown(KeyCode.E))
-                    this.interactor.Interact();
-            }
-        }
-
         #endregion
 
 

--- a/Assets/Scripts/PlayerControls.cs
+++ b/Assets/Scripts/PlayerControls.cs
@@ -80,7 +80,7 @@ namespace Underconnected
                 if (this.movementInput.sqrMagnitude > Mathf.Epsilon)
                     this.targetYaw = Vector3.SignedAngle(this.movementInput, Vector3.forward, Vector3.down);
 
-                if (Input.GetKeyDown(KeyCode.E))
+                if (this.ControlsEnabled && Input.GetKeyDown(KeyCode.E))
                     this.interactor.Interact();
             }
         }

--- a/Assets/Scripts/PlayerControls.cs
+++ b/Assets/Scripts/PlayerControls.cs
@@ -8,12 +8,13 @@ namespace Underconnected
     /// <summary>
     /// Allows the player to move the game object this component is on.
     /// </summary>
-    [RequireComponent(typeof(Player))]
+    [RequireComponent(typeof(Player), typeof(Interactor))]
     public class PlayerControls : NetworkBehaviour
     {
         [SerializeField] Rigidbody rigidBody;
         [SerializeField] MeshRenderer playerModelRenderer;
         [SerializeField] Player player;
+        [SerializeField] Interactor interactor;
         [SerializeField] float moveSpeed = 100.0F;
         [SerializeField] float rotationSpeed = 500.0F;
 
@@ -78,6 +79,9 @@ namespace Underconnected
 
                 if (this.movementInput.sqrMagnitude > Mathf.Epsilon)
                     this.targetYaw = Vector3.SignedAngle(this.movementInput, Vector3.forward, Vector3.down);
+
+                if (Input.GetKeyDown(KeyCode.E))
+                    this.interactor.Interact();
             }
         }
         /// <summary>

--- a/Assets/Scripts/PlayerControls.cs
+++ b/Assets/Scripts/PlayerControls.cs
@@ -8,12 +8,24 @@ namespace Underconnected
     /// <summary>
     /// Allows the player to move the game object this component is on.
     /// </summary>
+    [RequireComponent(typeof(Player))]
     public class PlayerControls : NetworkBehaviour
     {
         [SerializeField] Rigidbody rigidBody;
         [SerializeField] MeshRenderer playerModelRenderer;
+        [SerializeField] Player player;
         [SerializeField] float moveSpeed = 100.0F;
         [SerializeField] float rotationSpeed = 500.0F;
+
+
+        /// <summary>
+        /// The player these controls belong to.
+        /// </summary>
+        public Player Player => this.player;
+        /// <summary>
+        /// Tells whether the controls are enabled for this player.
+        /// </summary>
+        public bool ControlsEnabled { get; private set; }
 
 
         /// <summary>
@@ -36,6 +48,7 @@ namespace Underconnected
         private void Awake()
         {
             this.movementInput = Vector3.zero;
+            this.EnableControls();
         }
 
         private void Start()
@@ -57,11 +70,11 @@ namespace Underconnected
         /// </summary>
         private void Update()
         {
-            if (this.hasAuthority)
+            if (this.player.IsOwnPlayer)
             {
-                this.movementInput.x = Input.GetAxisRaw("Horizontal");
+                this.movementInput.x = this.ControlsEnabled ? Input.GetAxisRaw("Horizontal") : 0;
                 this.movementInput.y = 0;
-                this.movementInput.z = Input.GetAxisRaw("Vertical");
+                this.movementInput.z = this.ControlsEnabled ? Input.GetAxisRaw("Vertical") : 0;
 
                 if (this.movementInput.sqrMagnitude > Mathf.Epsilon)
                     this.targetYaw = Vector3.SignedAngle(this.movementInput, Vector3.forward, Vector3.down);
@@ -73,7 +86,7 @@ namespace Underconnected
         /// </summary>
         private void FixedUpdate()
         {
-            if (this.hasAuthority)
+            if (this.player.IsOwnPlayer)
             {
                 Vector3 currentRotation = this.rigidBody.rotation.eulerAngles;
                 float yawDelta = this.targetYaw - currentRotation.y;
@@ -84,6 +97,17 @@ namespace Underconnected
                 this.rigidBody.AddForce(this.movementInput.normalized * this.moveSpeed);
             }
         }
+
+
+        /// <summary>
+        /// Enables the player controls.
+        /// </summary>
+        public void EnableControls() => this.ControlsEnabled = true;
+        /// <summary>
+        /// Disables the player controls.
+        /// </summary>
+        public void DisableControls() => this.ControlsEnabled = false;
+
 
         /// <summary>
         /// Called when the value of <see cref="playerColor"/> changes on the server.


### PR DESCRIPTION
Changes:
- Implemented disabling player controls for each client's own player when the level timer expires
- Moved interaction input checking code from Player to PlayerContols

Closes #106 