### PR TITLE
Increase server tick rate

### DIFF
--- a/Assets/Prefabs/NetworkManager.prefab
+++ b/Assets/Prefabs/NetworkManager.prefab
@@ -80,7 +80,7 @@ MonoBehaviour:
   runInBackground: 1
   startOnHeadless: 1
   showDebugMessages: 0
-  serverTickRate: 10
+  serverTickRate: 40
   offlineScene: 
   onlineScene: 
   transport: {fileID: 4268389510805711341}


### PR DESCRIPTION
Changes:
- Increased the server tick rate to try to fix the desync

It did not really affect anything. I also tried using a custom synchronizer script and Mirror's NetworkRigidbody but none of them were satisfying. It is a problem with Mirror that a NetworkTransform does not synchronize its position correctly.
Closes #111 